### PR TITLE
feat: migrate npm publishing from classic tokens to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm publish --provenance --access public
+      - name: Publish to npm with OIDC
+        run: npm publish --access public
       - name: Install package
         run: npm i --location=global deploy-notify-slack@$(npm run version --silent)
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,16 +7,21 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://npm.pkg.github.com'
@@ -45,14 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish --provenance --access public
       - name: Install package
         run: npm i --location=global deploy-notify-slack@$(npm run version --silent)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-notify-slack",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "private": false,
   "description": "Send Slack notification about deploy with version comments",
   "main": "notify.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-notify-slack",
-  "version": "0.6.0",
+  "version": "0.5.10",
   "private": false,
   "description": "Send Slack notification about deploy with version comments",
   "main": "notify.js",


### PR DESCRIPTION
- Add permissions block for OIDC (id-token: write, contents: read, packages: write)
- Update publish-npm job to use Node.js 24 (npm v11 with native OIDC support)
- Replace NPM_TOKEN authentication with --provenance flag for OIDC publishing
- Update GitHub Actions to v4 (checkout, setup-node)